### PR TITLE
Added box shadow to improve text readability

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = class SpotifyBackgrounds extends Plugin {
                 background.backgroundImage = `url(${image})`
                 background.backgroundSize = "cover"
                 background.filter = "none"
+                background.boxShadow = "inset 0 0 0 1000px rgb(0 0 0 / 60%)"
                 
             }
 


### PR DESCRIPTION
I loved the plugin but found it rather hard to read the text elements on a lot of album covers so I added a box shadow to the top section so that you can still read the profile text elements on most album covers. Something between 0.6 and 0.8 opacity is ideal for readability. 

Feel to disregard this PR as it's mostly a personal preference cosmetic PR.